### PR TITLE
Add golf score input grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,75 @@
       left: 0;
       padding: 10px;
     }
+
+    .score-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 60px;
+      text-align: center;
+    }
+
+    .score-table th {
+      font-weight: bold;
+      padding: 4px;
+    }
+
+    .score-table td {
+      padding: 4px;
+    }
+
+    .score-input {
+      width: 40px;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
   <div class="top-left">Hello World</div>
+  <table class="score-table">
+    <tr>
+      <th>Hole</th>
+      <th>1</th>
+      <th>2</th>
+      <th>3</th>
+      <th>4</th>
+      <th>5</th>
+      <th>6</th>
+      <th>7</th>
+      <th>8</th>
+      <th>9</th>
+      <th>10</th>
+      <th>11</th>
+      <th>12</th>
+      <th>13</th>
+      <th>14</th>
+      <th>15</th>
+      <th>16</th>
+      <th>17</th>
+      <th>18</th>
+    </tr>
+    <tr>
+      <td>Score</td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+      <td><input type="number" min="0" class="score-input"></td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "match_play",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add score table to the home page for entering hole scores
- add npm package.json for basic npm commands

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6859c9f680c083329dfe85f49e21944c